### PR TITLE
Update devcontainer to Node 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "BearAtlas Dev Container",
   "features": {
-    "ghcr.io/devcontainers/features/node:20": {},
+    "ghcr.io/devcontainers/features/node:22": {},
     "ghcr.io/devcontainers/features/docker-in-docker": {}
   },
   "forwardPorts": [3000],


### PR DESCRIPTION
## ✨ What’s new
- switch devcontainer Node feature to version 22

## ✅ Checklist
- [ ] CI green (tests & lint)
- [ ] Docs updated if needed
- [ ] No breaking changes without semver bump

------
https://chatgpt.com/codex/tasks/task_e_684c2c63ae80832680f0837f70ea91e4

## Summary by Sourcery

Enhancements:
- Switch the devcontainer's Node.js feature to version 22