### PR TITLE
chore(ci): split workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,17 @@
+## ✨ What's new
+- _Explain the change in one sentence._
+
 ## Summary
 - Closes: <!-- issue # -->
 - Deployed preview: `https://bearatlas-pr-${{PR_NUMBER}}.fly.dev` *(replace PR_NUMBER with the PR number)*
 
 ### Screenshots / Screencast
 <!-- Drag & drop or link -->
+
+## ✅ Checklist
+- [ ] CI green (tests & lint)
+- [ ] Docs updated if needed
+- [ ] No breaking changes without semver bump
 
 ## Reviewer Notes
 - [ ] Functionally tested

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           cache: yarn
       - name: Restore node_modules
         id: node-cache
-        uses: actions/cache@v3
+    needs: [build, lint]
         with:
-          path: node_modules
+    needs: [build, lint]
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         if: steps.node-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,14 @@ jobs:
         with:
           node-version: 22
           cache: yarn
+      - name: Restore node_modules
+        id: node-cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
       - name: Build
         run: |
@@ -34,8 +41,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Lint
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.lint))"; then
@@ -53,8 +63,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Test
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.test))"; then
@@ -72,8 +85,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: E2E
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.e2e))"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +27,18 @@ jobs:
           else
             echo 'skip lint'
           fi
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Test
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.test))"; then
@@ -34,6 +46,18 @@ jobs:
           else
             echo 'skip test'
           fi
+
+  e2e:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: E2E
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.e2e))"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
   test:
-    needs: [build, lint]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
           fi
 
   e2e:
-    needs: [build, lint]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: |
+          yarn web build
+          yarn api build
+          docker compose build web
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           yarn api build
           docker compose build web
   lint:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
           fi
 
   test:
-    needs: lint
+    needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +64,7 @@ jobs:
           fi
 
   e2e:
-    needs: lint
+    needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## ✨ What’s new
- split CI workflow into `lint`, `test`, and `e2e` jobs

## ✅ Checklist
- [ ] CI green (tests & lint)
- [ ] Docs updated if needed
- [ ] No breaking changes without semver bump

------
https://chatgpt.com/codex/tasks/task_e_684c84805da48326b5a23040ecc11804

## Summary by Sourcery

Split the GitHub Actions pipeline into dedicated lint, test, and e2e jobs with dependencies to improve CI clarity and execution order.

CI:
- Split CI workflow into separate lint, test, and e2e jobs.
- Configure test and e2e jobs to depend on the lint job.