### PR TITLE
Use artifacts to reuse node_modules across jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,15 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Upload node_modules
-        uses: actions/upload-artifact@v4
+      - name: Restore node_modules
+        id: node-cache
+        uses: actions/cache@v3
         with:
-          name: node-modules
           path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
       - name: Build
         run: |
           yarn web build
@@ -39,11 +41,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
+      - name: Restore node_modules
+        uses: actions/cache@v3
         with:
-          name: node-modules
           path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Lint
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.lint))"; then
@@ -61,11 +63,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
+      - name: Restore node_modules
+        uses: actions/cache@v3
         with:
-          name: node-modules
           path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Test
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.test))"; then
@@ -83,11 +85,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
+      - name: Restore node_modules
+        uses: actions/cache@v3
         with:
-          name: node-modules
           path: node_modules
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: E2E
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.e2e))"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Upload node_modules
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - name: Build
         run: |
           yarn web build
@@ -34,8 +39,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - name: Lint
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.lint))"; then
@@ -53,8 +61,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - name: Test
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.test))"; then
@@ -72,8 +83,11 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
       - name: E2E
         run: |
           if [ -f package.json ] && node -e "p=require('./package.json');process.exit(!(p.scripts && p.scripts.e2e))"; then


### PR DESCRIPTION
## Summary
- Closes: <!-- issue # -->
- Deployed preview: `https://bearatlas-pr-${{PR_NUMBER}}.fly.dev`

### Screenshots / Screencast
<!-- Drag & drop or link -->

## Reviewer Notes
- [ ] Functionally tested
- [ ] Docs updated
- [ ] Migrations run (`prisma migrate deploy`)

------
https://chatgpt.com/codex/tasks/task_e_684cbd25e6f4832685c381c7a68a6abe

## Summary by Sourcery

Use GitHub Actions artifacts to share installed dependencies across CI jobs and eliminate redundant yarn installs

CI:
- Upload node_modules artifact after dependency installation
- Download node_modules artifact in lint, test, and E2E jobs to reuse dependencies